### PR TITLE
fix: ignore errors for log_publishing_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+### Changed
+
+- Ignore errors for log_publishing_options
+
+## [0.4.4]
+
 ## [0.4.3] - 2021-08-17
 
 ### Added

--- a/main.tf
+++ b/main.tf
@@ -112,4 +112,8 @@ POLICY
   depends_on = [
     aws_iam_service_linked_role.es,
   ]
+
+  lifecycle {
+    ignore_changes = [log_publishing_options]
+  }
 }


### PR DESCRIPTION
# Description

This change adds a lifecycle block to ignore any changes related to `log_publishing_options`. This problem is well known and reported [here](https://github.com/hashicorp/terraform-provider-aws/issues/5752).

Fixes #(issue)

# Checklist:

- [x] Update the changelog with any notable changes such as features added, changed, fixed, and/or removed.
- [ ] I have made corresponding changes to the documentation
